### PR TITLE
Simplify bare simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,25 @@
  instigating a propagation of failure among threads if one unexpectedly dies.
 
 
- # Examples
- ## Simple bare usage
- ```
- extern crate bus_queue;
- use bus_queue::bare_channel;
+# Examples
+## Simple bare usage
+```
+extern crate bus_queue;
+
+use bus_queue::bare_channel;
 
 fn main() {
-    let (mut tx,rx) = bare_channel(1);
+    let (mut tx, rx) = bare_channel(10);
+    (1..15).for_each(|x| tx.broadcast(x).unwrap());
 
-    tx.broadcast(4).unwrap();
-    assert_eq!(4,*rx.try_recv().unwrap());
+    let received: Vec<i32> = rx.into_iter().map(|x| *x).collect();
+    // Test that only the last 10 elements are in the received list.
+    let expected: Vec<i32> = (5..15).collect();
+
+    assert_eq!(expected, received);
 }
- ```
+```
+
  ## Simple synchronous usage
  ```
  extern crate bus_queue;

--- a/examples/bare-simple.rs
+++ b/examples/bare-simple.rs
@@ -4,11 +4,11 @@ use bus_queue::bare_channel;
 
 fn main() {
     let (mut tx, rx) = bare_channel(10);
-    vec![1, 2, 3, 4]
-        .into_iter()
-        .for_each(|x| tx.broadcast(x).unwrap());
+    (1..15).for_each(|x| tx.broadcast(x).unwrap());
 
     let received: Vec<i32> = rx.into_iter().map(|x| *x).collect();
+    // Test that only the last 10 elements are in the received list.
+    let expected: Vec<i32> = (5..15).collect();
 
-    assert_eq!(vec![1, 2, 3, 4], received);
+    assert_eq!(expected, received);
 }


### PR DESCRIPTION
Simplify the code and redo the scenario so that more elements are inserted than the length of the circular buffer.