### PR TITLE
Add GetSubCount trait, and implement it for bare, sync, and async_

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bus_queue"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Filip Dulic <filip.dulic@gmail.com>", "Vladan Popovic <vladanovic@gmail.com>", "Bojan Petrovic <bojan_petrovic@fastmail.fm>"]
 description = "Lock-free Bounded non-Blocking Pub-Sub Queue"
 license = "Apache-2.0/MIT"

--- a/src/async_.rs
+++ b/src/async_.rs
@@ -35,6 +35,12 @@ impl<T: Send> Publisher<T> {
     }
 }
 
+impl<T: Send> GetSubCount for Publisher<T> {
+    fn get_sub_count(&self) -> usize {
+        self.bare_publisher.get_sub_count()
+    }
+}
+
 impl<T: Send> Sink for Publisher<T> {
     type SinkItem = T;
     type SinkError = SendError<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,9 @@ pub struct BareSubscriber<T: Send> {
     is_pub_available: Arc<AtomicBool>,
 }
 
+pub trait GetSubCount {
+    fn get_sub_count(&self) -> usize;
+}
 /// Function used to create and initialise a ( BarePublisher, BareSubscriber ) tuple.
 pub fn bare_channel<T: Send>(size: usize) -> (BarePublisher<T>, BareSubscriber<T>) {
     let size = size + 1;
@@ -237,6 +240,12 @@ impl<T: Send> BarePublisher<T> {
         self.buffer[self.wi.get() % self.size].store(Some(Arc::new(object)));
         self.wi.inc();
         Ok(())
+    }
+}
+
+impl<T: Send> GetSubCount for BarePublisher<T> {
+    fn get_sub_count(&self) -> usize {
+        self.sub_cnt.get()
     }
 }
 /// Drop trait is used to let subscribers know that publisher is no longer available.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -53,6 +53,12 @@ impl<T: Send> Publisher<T> {
     }
 }
 
+impl<T: Send> GetSubCount for Publisher<T> {
+    fn get_sub_count(&self) -> usize {
+        self.bare_publisher.get_sub_count()
+    }
+}
+
 impl<T: Send> Drop for Publisher<T> {
     fn drop(&mut self) {
         self.wake_all();


### PR DESCRIPTION
Created a GetSubCount trait with the get_sub_count method, and implemented it for BarePublisher, async_::Publisher, sync::Publisher.