### PR TITLE
Fixed the async example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ readme = "README.md"
 lockfree = "^0.5.1"
 arc-swap = "0.3.6"
 futures = {version = "0.1", optional = true}
-tokio = {version = "0.1", optional = true}
+
+[dev-dependencies]
+tokio = "0.1"
 
 [features]
 default = ["async"]
 async = ["futures"]
-async-example = ["tokio"]
 
 [[example]]
 name = "bare-simple"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! use bus_queue::async_;
 //! use futures::*;
-//! use tokio::runtime::Runtime;
+//! use tokio::runtime::current_thread::Runtime;
 //!
 //! fn main() {
 //!     let mut rt = Runtime::new().unwrap();


### PR DESCRIPTION
- Added tokio as a dev-dependency
- Use "current_thread" tokio runtime

The current_thread tokio runtime ensures that the publisher has finished
publishing before the subscribers start to receive. The example may fail
in the default thread_pool runtime as there is a race condition between
the publisher and subscriber, where the subscriber may start receiving before
the publisher has completed and therefore, get more than the last 10 messages.