### PR TITLE
Removed waker/sleeper from async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ readme = "README.md"
 lockfree = "^0.5.1"
 arc-swap = "0.3.6"
 futures = {version = "0.1", optional = true}
-tokio = {version = "0.1", optional = true}
+
+[dev-dependencies]
+tokio = "0.1"
 
 [features]
 default = ["async"]
 async = ["futures"]
-async-example = ["tokio"]
 
 [[example]]
 name = "bare-simple"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,8 @@ pub fn alarm<T>(current: T) -> (Waker<T>, Sleeper<T>) {
     )
 }
 
+#[cfg(test)]
+extern crate tokio;
 pub mod sync;
 #[cfg(feature = "async")]
 extern crate futures;


### PR DESCRIPTION
All that tokio requires to call the poll method of a leaf future/stream
is for the current task to be notified when returning `NotReady`.

Added a test in async to show that this works.

It was strange to me that it worked without the waker/sleeper, and I'm still a bit blurry on tokio so I may be missing something. Genuinely curious on your thoughts here and if this PR make sense to this project.