### PR TITLE
Set missed items size and upgrade futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-arc-swap = "0.4.2"
-futures = { version = "=0.3.0-alpha.18", package = "futures-preview", features = ["async-await", "nightly"] }
+arc-swap = "0.4.6"
+futures = "0.3.4"
 crossbeam-channel = "0.3.9"
 
 [[example]]

--- a/examples/async-simple.rs
+++ b/examples/async-simple.rs
@@ -4,7 +4,7 @@ use futures::stream;
 use futures::StreamExt;
 
 fn main() {
-    let (publisher, subscriber1) = bounded(10);
+    let (publisher, subscriber1) = bounded(10, 0);
     let subscriber2 = subscriber1.clone();
 
     block_on(async move {

--- a/examples/raw-simple.rs
+++ b/examples/raw-simple.rs
@@ -3,7 +3,7 @@ extern crate bus_queue;
 use bus_queue::raw_bounded;
 
 fn main() {
-    let (tx, rx) = raw_bounded(10);
+    let (tx, rx) = raw_bounded(10, 0);
     (1..15).for_each(|x| tx.broadcast(x).unwrap());
 
     let received: Vec<i32> = rx.map(|x| *x).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@
 //! use bus_queue::raw_bounded;
 //!
 //! fn main() {
-//!     let (tx, rx) = raw_bounded(10);
-//!     (1..15).for_each(|x| tx.broadcast(x).unwrap());
+//!     let (tx, rx) = raw_bounded(10, 0);
+//!     (1..15).for_each(|x| { tx.broadcast(x).unwrap() });
 //!
 //!     let received: Vec<i32> = rx.map(|x| *x).collect();
 //!     // Test that only the last 10 elements are in the received list.
@@ -66,7 +66,7 @@
 //! # use futures::StreamExt;
 //! # use futures::stream;
 //!
-//!    let (publisher, subscriber1) = bounded(10);
+//!    let (publisher, subscriber1) = bounded(10, 0);
 //!    let subscriber2 = subscriber1.clone();
 //!
 //!    block_on(async move {


### PR DESCRIPTION
Add a `missed_items_size: usize` argument to the `bounded` method so
that the user can designate how much items should be ignored when the
writer overflows a slow reading client.

This is handy in high throughput scenarios where we want to ignore all
previous messages and send the last one in the buffer to the slow
readers.