### PR TITLE
Re-introduce the loop in try_receive

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -124,13 +124,15 @@ impl<T> Receiver<T> {
 
         // Reader has not read enough to keep up with (writer - buffer size) so
         // set the reader pointer to be (writer - buffer size)
-        if self.wi.get() - self.ri.get() >= self.size {
-            self.ri
-                .set(self.wi.get() - self.size + self.missed_items_size);
+        loop {
+            let val = self.buffer[self.ri.get() % self.size].load_full().unwrap();
+            if self.wi.get() - self.ri.get() > self.size {
+                self.ri.set(self.wi.get() - self.size + self.skip_items);
+            } else {
+                self.ri.inc();
+                return Ok(val);
+            }
         }
-        let val = self.buffer[self.ri.get() % self.size].load_full().unwrap();
-        self.ri.inc();
-        return Ok(val);
     }
 }
 


### PR DESCRIPTION
This is due to a possible race condition where the writer can overflow
the reader after the value was read from the buffer.

The scenario is the following:

 1. The reader index is at the bottom (writer index - queue size), so
    the check before this patch would pass.

2a. The writer has set another value and has overflown the reader.
2b. The reader reads the value at it's index position.

 3. The reader returns a value that was the most recent write, instead
    of getting and returning the oldest inserted value in the ring
    buffer.


This patch first reads the value from the buffer and then checks for
the index consistency. If that check passes it immediately returns,
which would make this race condition impossible.

If the consistency check fails, it resets the reader index to the
current lowest index of the ring buffer and goes back to the beginning
of the loop.