### PR TITLE
#29 panic on index overflow

### DIFF
--- a/src/atomic_counter.rs
+++ b/src/atomic_counter.rs
@@ -21,7 +21,9 @@ impl AtomicCounter {
     }
     #[inline]
     pub fn inc(&self) {
-        self.count.fetch_add(1, Ordering::AcqRel);
+        if self.count.fetch_add(1, Ordering::AcqRel) == usize::MAX {
+            panic!("usize overflow in AtomicCounter!");
+        }
     }
     #[inline]
     pub fn dec(&self) {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -337,4 +337,14 @@ mod test {
         // Receiver still expects the oldest value in buffer to be returned.
         assert_eq!(*receiver.try_recv().unwrap(), 1);
     }
+
+    #[test]
+    #[should_panic]
+    fn writer_overflows_pass_usize_max()
+    {
+        let (sender, _receiver) = bounded(3);
+        // set Sender wi index to usize::MAX
+        sender.wi.set(usize::MAX);
+        sender.broadcast(1).unwrap();
+    }
 }


### PR DESCRIPTION
Closes #29 
Buffer index overflow over usize::MAX is now handled with a panic.