### PR TITLE
Import AtomicArc and implement AtomicArc flavor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,12 @@ jobs:
           command: test
           arg: --no-default-features --features=rwlock,rwlock-export
 
+      - name: Run cargo test atomic-arc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          arg: --no-default-features --features=atomic-arc,atomic-arc-export
+
   lints:
     name: Lints
     runs-on: ubuntu-latest
@@ -77,3 +83,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --no-default-features --features=rwlock,rwlock-export
+
+      - name: Run cargo clippy atomic-arc
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --no-default-features --features=atomic-arc,atomic-arc-export

--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.9.0'
-          args: '-- --test-threads 1'
+          args: '--features=atomic-arc,rwlock -- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /target
 **/*.rs.bk
-.idea/
 Cargo.lock
-*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ arcswap = ["arc-swap"]
 # conc-atomic = ["conc"]
 rwlock = []
 rwlock-export = []
+atomic-arc = []
+atomic-arc-export = []
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ rwlock-export = []
 atomic-arc = []
 atomic-arc-export = []
 
-
-
-
 [[example]]
 name = "raw-simple"
 path = "examples/raw-simple.rs"

--- a/src/atomic/atomic_arc.rs
+++ b/src/atomic/atomic_arc.rs
@@ -1,0 +1,238 @@
+//! This file was copied from https://github.com/stjepang/atomic
+//! Original author "Stjepan Glavina <stjepang@gmail.com>", all rights are his
+//! It will only be temporarily used until the project is published by the
+//! original author on crates.io or until the author asks for it's removal.
+use std::marker::PhantomData;
+use std::mem;
+use std::ptr;
+use std::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use super::hazard;
+
+// TODO: ZSV are all allocated at address 0x1 - what about transfering drop resp.?
+// - maybe we should for ZST in destroy_object() and always destroy?
+
+pub struct AtomicArc<T> {
+    object: AtomicPtr<T>,
+    _marker: PhantomData<Option<Arc<T>>>,
+}
+
+unsafe impl<T: Send + Sync> Send for AtomicArc<T> {}
+unsafe impl<T: Send + Sync> Sync for AtomicArc<T> {}
+
+#[allow(dead_code)]
+impl<T> AtomicArc<T> {
+    pub fn new<U>(val: U) -> AtomicArc<T>
+    where
+        U: Into<Option<Arc<T>>>,
+    {
+        AtomicArc {
+            object: AtomicPtr::new(into_raw(val)),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn into_inner(self) -> Option<Arc<T>> {
+        let raw = self.object.load(Ordering::Relaxed);
+        mem::forget(self);
+
+        if raw.is_null() {
+            None
+        } else {
+            unsafe { Some(Arc::from_raw(raw)) }
+        }
+    }
+
+    pub fn get(&self) -> SharedArc<T> {
+        let slot = unsafe { &*hazard::allocate_slot() };
+
+        let mut object = self.object.load(Ordering::Relaxed);
+
+        loop {
+            if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+                // HACK(stjepang): On x86 architectures there are two different ways of executing a
+                // `SeqCst` fence.
+                //
+                // 1. `atomic::fence(SeqCst)`, which compiles into a `mfence` instruction.
+                // 2. `_.compare_and_swap(_, _, SeqCst)`, which compiles into a `lock cmpxchg`
+                //    instruction.
+                //
+                // Both instructions have the effect of a full barrier, but benchmarks have shown
+                // that the second one makes the algorithm faster in this particular case.
+                let previous = slot.compare_and_swap(0, object as usize, Ordering::SeqCst);
+                debug_assert_eq!(previous, 0);
+            } else {
+                slot.store(object as usize, Ordering::Relaxed);
+                atomic::fence(Ordering::SeqCst);
+            }
+
+            let shared = SharedArc {
+                object,
+                slot,
+                _marker: PhantomData,
+            };
+
+            let new = self.object.load(Ordering::Relaxed);
+            if new == object {
+                return shared;
+            }
+            object = new;
+
+            // Deallocate the slot, potentially destroying the protected object.
+            drop(shared);
+        }
+    }
+
+    pub fn replace<U>(&self, val: U) -> SharedArc<T>
+    where
+        U: Into<Option<Arc<T>>>,
+    {
+        let old = self.object.swap(into_raw(val), Ordering::SeqCst);
+        SharedArc {
+            object: old,
+            slot: ptr::null(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn set<U>(&self, val: U)
+    where
+        U: Into<Option<Arc<T>>>,
+    {
+        self.replace(val.into());
+    }
+
+    #[allow(clippy::collapsible_if)]
+    pub fn compare_and_set<U>(&self, current: &SharedArc<T>, new: U) -> Result<(), Option<Arc<T>>>
+    where
+        U: Into<Option<Arc<T>>>,
+    {
+        let new = into_raw(new);
+        let old = current.object;
+
+        if self.object.compare_and_swap(old, new, Ordering::SeqCst) == old {
+            drop(SharedArc {
+                object: old,
+                slot: ptr::null(),
+                _marker: PhantomData,
+            });
+            Ok(())
+        } else {
+            if new.is_null() {
+                Err(None)
+            } else {
+                unsafe { Err(Some(Arc::from_raw(new))) }
+            }
+        }
+    }
+}
+
+impl<T> Drop for AtomicArc<T> {
+    fn drop(&mut self) {
+        // 1) Either somebody is holding a reference to this element and we want to move
+        //    responsibility of calling a drop(T) to them.
+        // 2) Nobody is holding a reference to this element, therefore we are in charge of dropping
+        //    an element.
+
+        let obj = self.object.load(Ordering::Relaxed);
+
+        if hazard::registry().destroy_object(obj as usize) {
+            unsafe {
+                drop(Arc::from_raw(obj));
+            }
+        }
+    }
+}
+
+impl<T, U> From<U> for AtomicArc<T>
+where
+    U: Into<Option<Arc<T>>>,
+{
+    fn from(val: U) -> AtomicArc<T> {
+        AtomicArc {
+            object: AtomicPtr::new(into_raw(val)),
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct SharedArc<T> {
+    object: *mut T,
+    slot: *const AtomicUsize,
+    _marker: PhantomData<Option<Arc<T>>>,
+}
+
+impl<T> SharedArc<T> {
+    pub fn clone_inner(&self) -> Option<Arc<T>> {
+        let arc = if self.object.is_null() {
+            None
+        } else {
+            unsafe { Some(Arc::from_raw(self.object)) }
+        };
+
+        // Increment the reference count.
+        mem::forget(arc.clone());
+
+        arc
+    }
+
+    pub fn as_ref(&self) -> Option<&T> {
+        unsafe { self.object.as_ref() }
+    }
+
+    // TODO: try_unwrap() and wait_unwrap()
+
+    fn slot(&self) -> Option<&AtomicUsize> {
+        unsafe { self.slot.as_ref() }
+    }
+}
+
+impl<T> Drop for SharedArc<T> {
+    #[inline]
+    fn drop(&mut self) {
+        // Set the slot back to zero. If it has been modified, that means we've been notified that
+        // the object must be destroyed and it's our responsibility to do so.
+        //
+        // If the slot is not even allocatedt, this `SharedArc` was implicitly responsible for
+        // destroying the object from the start.
+        if let Some(slot) = self.slot() {
+            if slot.swap(0, Ordering::Acquire) == self.object as usize {
+                // Nothing to do! This is the common case.
+                return;
+            }
+        }
+
+        #[cold]
+        fn destroy<T>(object: *const T) {
+            if hazard::registry().destroy_object(object as usize) {
+                unsafe {
+                    drop(Arc::from_raw(object));
+                }
+            }
+        }
+        destroy(self.object)
+    }
+}
+
+impl<T> Into<Option<Arc<T>>> for SharedArc<T> {
+    fn into(self) -> Option<Arc<T>> {
+        self.clone_inner()
+    }
+}
+
+impl<'a, T> Into<Option<Arc<T>>> for &'a SharedArc<T> {
+    fn into(self) -> Option<Arc<T>> {
+        self.clone_inner()
+    }
+}
+
+fn into_raw<T, U>(val: U) -> *mut T
+where
+    U: Into<Option<Arc<T>>>,
+{
+    match val.into() {
+        None => ptr::null_mut(),
+        Some(val) => Arc::into_raw(val) as *mut T,
+    }
+}

--- a/src/atomic/hazard.rs
+++ b/src/atomic/hazard.rs
@@ -1,0 +1,173 @@
+//! This file was copied from https://github.com/stjepang/atomic
+//! Original author "Stjepan Glavina <stjepang@gmail.com>", all rights are his
+//! It will only be temporarily used until the project is published by the
+//! original author on crates.io or until the author asks for it's removal.
+use std::ptr;
+use std::sync::atomic::{self, AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+
+// TODO: if needs_drop is false, add retiring object to a freelist, and use sizeof to track memory
+
+pub fn allocate_slot() -> *const AtomicUsize {
+    LOCAL.with(|local| local.allocate_slot() as *const AtomicUsize)
+}
+
+#[derive(Default)]
+struct ThreadEntry {
+    slots: [AtomicUsize; 6],
+    next: AtomicPtr<ThreadEntry>,
+    in_use: AtomicBool,
+}
+
+#[derive(Default)]
+pub struct Registry {
+    entries: [ThreadEntry; 32],
+    next: AtomicPtr<Registry>,
+}
+
+static REGISTRY: AtomicPtr<Registry> = AtomicPtr::new(ptr::null_mut());
+
+#[allow(clippy::cmp_null)]
+fn try_extend_registry(ptr: &AtomicPtr<Registry>) {
+    let instance = Box::into_raw(Box::new(Registry::default()));
+
+    if ptr.compare_and_swap(ptr::null_mut(), instance, Ordering::SeqCst) != ptr::null_mut() {
+        // Some other thread has successfully extended Registry.
+        // It is our job now to delete `instance` we have just created.
+        unsafe { drop(Box::from_raw(instance)) }
+    }
+}
+
+#[inline]
+pub fn registry() -> &'static Registry {
+    let mut registry = REGISTRY.load(Ordering::Acquire);
+
+    if registry.is_null() {
+        try_extend_registry(&REGISTRY);
+        registry = REGISTRY.load(Ordering::Acquire);
+    }
+
+    unsafe { &(*registry) }
+}
+
+impl Registry {
+    #[cold]
+    pub fn destroy_object(&self, obj: usize) -> bool {
+        if obj == 0 {
+            false
+        } else {
+            !self.try_transfer_drop_responsibility(obj)
+        }
+    }
+
+    #[allow(clippy::collapsible_if)]
+    fn register(&self) -> *const ThreadEntry {
+        for entry in self.entries.iter() {
+            if !entry.in_use.load(Ordering::SeqCst) {
+                if !entry.in_use.swap(true, Ordering::SeqCst) {
+                    return entry;
+                }
+            }
+        }
+
+        let mut next = self.next.load(Ordering::SeqCst);
+
+        if next.is_null() {
+            try_extend_registry(&self.next);
+            next = self.next.load(Ordering::SeqCst);
+        }
+
+        unsafe { (*next).register() }
+    }
+
+    #[allow(clippy::collapsible_if)]
+    fn try_transfer_drop_responsibility(&self, ptr: usize) -> bool {
+        debug_assert_ne!(ptr, 0);
+
+        atomic::fence(Ordering::SeqCst);
+
+        for entry in self.entries.iter() {
+            if entry.in_use.load(Ordering::Acquire) {
+                if entry.try_transfer_drop_responsibility(ptr) {
+                    return true;
+                }
+            }
+        }
+
+        unsafe {
+            let next = self.next.load(Ordering::Acquire);
+
+            if !next.is_null() {
+                (*next).try_transfer_drop_responsibility(ptr)
+            } else {
+                false
+            }
+        }
+    }
+}
+
+impl ThreadEntry {
+    fn unregister(&self) {
+        self.in_use.store(false, Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn allocate_slot(&self) -> *const AtomicUsize {
+        for slot in self.slots.iter() {
+            if slot.load(Ordering::Relaxed) == 0 {
+                return slot;
+            }
+        }
+
+        let mut next = self.next.load(Ordering::SeqCst);
+
+        if next.is_null() {
+            let new_entry = Box::into_raw(Box::new(ThreadEntry::default()));
+            self.next.store(new_entry, Ordering::SeqCst);
+            next = new_entry;
+        }
+
+        unsafe { (*next).allocate_slot() }
+    }
+
+    #[allow(clippy::needless_return)]
+    #[allow(clippy::collapsible_if)]
+    fn try_transfer_drop_responsibility(&self, ptr: usize) -> bool {
+        debug_assert_ne!(ptr, 0);
+
+        for slot in self.slots.iter() {
+            if slot.load(Ordering::SeqCst) == ptr {
+                if slot.compare_and_swap(ptr, 1, Ordering::SeqCst) == ptr {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}
+
+struct Local {
+    entry: *const ThreadEntry,
+}
+
+thread_local! {
+    static LOCAL: Local = Local::new();
+}
+
+impl Local {
+    pub fn new() -> Self {
+        Local {
+            entry: registry().register(),
+        }
+    }
+
+    #[inline]
+    fn allocate_slot(&self) -> &AtomicUsize {
+        unsafe { &*(*self.entry).allocate_slot() }
+    }
+}
+
+impl Drop for Local {
+    fn drop(&mut self) {
+        unsafe { (*self.entry).unregister() }
+    }
+}

--- a/src/atomic/mod.rs
+++ b/src/atomic/mod.rs
@@ -1,2 +1,8 @@
+//! This module was copied from https://github.com/stjepang/piper
+//! Original author "Stjepan Glavina <stjepang@gmail.com>", all rights are his
+//! It will only be temporarily used until the project is published by the
+//! original author on crates.io or until the author asks for it's removal.
+#[cfg_attr(tarpaulin, skip)]
 pub mod atomic_arc;
+#[cfg_attr(tarpaulin, skip)]
 mod hazard;

--- a/src/atomic/mod.rs
+++ b/src/atomic/mod.rs
@@ -1,0 +1,2 @@
+pub mod atomic_arc;
+mod hazard;

--- a/src/flavors/atomic_arc.rs
+++ b/src/flavors/atomic_arc.rs
@@ -1,0 +1,54 @@
+use crate::atomic::atomic_arc::AtomicArc;
+use crate::bus;
+use crate::channel;
+use crate::swap_slot::SwapSlot;
+use std::sync::Arc;
+
+pub type Slot<T> = AtomicArc<T>;
+
+impl<T> SwapSlot<T> for AtomicArc<T> {
+    fn store(&self, item: T) {
+        self.set(Some(Arc::new(item)));
+    }
+
+    fn load(&self) -> Arc<T> {
+        self.get().clone_inner().unwrap()
+    }
+
+    fn none() -> Self {
+        AtomicArc::new(None)
+    }
+}
+pub type Sender<T> = channel::Sender<T, AtomicArc<T>>;
+pub type Receiver<T> = channel::Receiver<T, AtomicArc<T>>;
+
+pub fn raw_bounded<T>(size: usize) -> (Sender<T>, Receiver<T>) {
+    channel::bounded::<T, AtomicArc<T>>(size)
+}
+
+pub type Publisher<T> = bus::Publisher<T, AtomicArc<T>>;
+pub type Subscriber<T> = bus::Subscriber<T, AtomicArc<T>>;
+
+pub fn bounded<T>(size: usize) -> (Publisher<T>, Subscriber<T>) {
+    bus::bounded::<T, AtomicArc<T>>(size)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::swap_slot::SwapSlot;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_atomic_arc() {
+        use crate::atomic::atomic_arc::AtomicArc;
+        let item = AtomicArc::none();
+        let none = item.get().clone_inner();
+        assert_eq!(none, None);
+        SwapSlot::store(&item, 1);
+        let arc = SwapSlot::load(&item);
+        assert_eq!(*arc, 1);
+        assert_eq!(Arc::strong_count(&arc), 2);
+        SwapSlot::store(&item, 1);
+        assert_eq!(Arc::strong_count(&arc), 1);
+    }
+}

--- a/src/flavors/mod.rs
+++ b/src/flavors/mod.rs
@@ -3,6 +3,9 @@ pub mod arc_swap;
 #[cfg(feature = "rwlock")]
 pub mod rw_lock;
 
+#[cfg(feature = "atomic-arc")]
+pub mod atomic_arc;
+
 // #[cfg(feature = "conc-atomic")]
 // pub mod conc_atomic {
 //     use std::sync::Arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,17 @@ pub mod flavors;
 pub(crate) mod piper;
 pub mod swap_slot;
 
-#[cfg(not(any(feature = "rwlock-export")))]
+#[cfg(feature = "atomic-arc")]
+mod atomic;
+
+#[cfg(not(any(feature = "rwlock-export", feature = "atomic-arc-export")))]
 pub use flavors::arc_swap::{bounded, raw_bounded, Publisher, Slot, Subscriber};
 
 #[cfg(feature = "rwlock-export")]
 pub use flavors::rw_lock::{bounded, raw_bounded, Publisher, Slot, Subscriber};
+
+#[cfg(feature = "atomic-arc-export")]
+pub use flavors::atomic_arc::{bounded, raw_bounded, Publisher, Slot, Subscriber};
 
 // #[cfg(feature = "conc-atomic")]
 // pub use flavors::conc_atomic::{bounded, raw_bounded, Publisher, Subscriber};

--- a/src/piper/mod.rs
+++ b/src/piper/mod.rs
@@ -1,1 +1,6 @@
+//! This module was copied from https://github.com/stjepang/piper
+//! Original author "Stjepan Glavina <stjepang@gmail.com>", all rights are his
+//! It will only be temporarily used until the project is published by the
+//! original author on crates.io or until the author asks for it's removal.
+#[cfg_attr(tarpaulin, skip)]
 pub(crate) mod event;


### PR DESCRIPTION
Closes #39

- Import hazard.rs and atomic_arc files from https://github.com/stjepang/atomic.
- Implement atomic_arc flavor.
- Cover atomic_arc flavor with test.