### PR TITLE
Remove tests for SwapSlot trait

### DIFF
--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -88,7 +88,9 @@ impl<T, S: SwapSlot<T>> Channel<T, S> {
                 );
             } else {
                 ri.inc();
-                return Ok(val);
+                // NOTE: unwrap is safe to use, because the reader would never read a slot that
+                // hasn't been written to.
+                return Ok(val.unwrap());
             }
         }
     }
@@ -226,7 +228,7 @@ mod test {
         // Should be reading from the last element in the buffer
         let index = (receiver.channel.wi.get() - receiver.channel.size + 1) % receiver.channel.size;
 
-        assert_eq!(*SwapSlot::load(&receiver.channel.buffer[index]), 7);
+        assert_eq!(*SwapSlot::load(&receiver.channel.buffer[index]).unwrap(), 7);
         assert_eq!(*receiver.try_recv().unwrap(), 7);
 
         // Cloned receiver start reading where the original receiver left off

--- a/src/flavors/arc_swap.rs
+++ b/src/flavors/arc_swap.rs
@@ -12,8 +12,8 @@ impl<T> SwapSlot<T> for ArcSwapOption<T> {
         self.store(Some(Arc::new(item)))
     }
 
-    fn load(&self) -> Arc<T> {
-        self.load_full().unwrap()
+    fn load(&self) -> Option<Arc<T>> {
+        self.load_full()
     }
 
     fn none() -> Self {
@@ -37,19 +37,33 @@ pub fn bounded<T>(size: usize) -> (Publisher<T>, Subscriber<T>) {
 #[cfg(test)]
 mod test {
     use crate::swap_slot::SwapSlot;
+    use arc_swap::ArcSwapOption;
     use std::sync::Arc;
 
     #[test]
-    fn test_arcswap() {
-        use arc_swap::ArcSwapOption;
+    fn test_archswap_none() {
+        let item: ArcSwapOption<()> = ArcSwapOption::none();
+
+        assert_eq!(item.load_full(), None);
+    }
+
+    #[test]
+    fn test_archswap_store() {
         let item = ArcSwapOption::none();
-        let none = ArcSwapOption::load_full(&item);
-        assert_eq!(none, None);
-        SwapSlot::store(&item, 1);
+
+        SwapSlot::store(&item, 5);
+
+        assert_eq!(item.load_full(), Some(Arc::new(5)));
+    }
+
+    #[test]
+    fn test_archswap_load() {
+        let item = ArcSwapOption::none();
+        SwapSlot::store(&item, 10);
+
         let arc = SwapSlot::load(&item);
-        assert_eq!(*arc, 1);
-        assert_eq!(Arc::strong_count(&arc), 2);
-        SwapSlot::store(&item, 1);
-        assert_eq!(Arc::strong_count(&arc), 1);
+
+        assert_eq!(arc, Some(Arc::new(10)));
+        assert_eq!(Arc::strong_count(&arc.unwrap()), 2)
     }
 }

--- a/src/flavors/atomic_arc.rs
+++ b/src/flavors/atomic_arc.rs
@@ -12,8 +12,8 @@ impl<T> SwapSlot<T> for AtomicArc<T> {
         self.set(Some(Arc::new(item)));
     }
 
-    fn load(&self) -> Arc<T> {
-        self.get().clone_inner().unwrap()
+    fn load(&self) -> Option<Arc<T>> {
+        self.get().clone_inner()
     }
 
     fn none() -> Self {
@@ -36,20 +36,34 @@ pub fn bounded<T>(size: usize) -> (Publisher<T>, Subscriber<T>) {
 
 #[cfg(test)]
 mod test {
+    use crate::atomic::atomic_arc::AtomicArc;
     use crate::swap_slot::SwapSlot;
     use std::sync::Arc;
 
     #[test]
-    fn test_atomic_arc() {
-        use crate::atomic::atomic_arc::AtomicArc;
+    fn test_atomicarc_none() {
+        let item: AtomicArc<i32> = AtomicArc::none();
+
+        assert_eq!(item.get().clone_inner(), None);
+    }
+
+    #[test]
+    fn test_atomicarc_store() {
         let item = AtomicArc::none();
-        let none = item.get().clone_inner();
-        assert_eq!(none, None);
-        SwapSlot::store(&item, 1);
+
+        SwapSlot::store(&item, 5);
+
+        assert_eq!(item.get().clone_inner(), Some(Arc::new(5)));
+    }
+
+    #[test]
+    fn test_atomicarc_load() {
+        let item = AtomicArc::none();
+        SwapSlot::store(&item, 10);
+
         let arc = SwapSlot::load(&item);
-        assert_eq!(*arc, 1);
-        assert_eq!(Arc::strong_count(&arc), 2);
-        SwapSlot::store(&item, 1);
-        assert_eq!(Arc::strong_count(&arc), 1);
+
+        assert_eq!(arc, Some(Arc::new(10)));
+        assert_eq!(Arc::strong_count(&arc.unwrap()), 2)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,4 +94,4 @@ pub use swap_slot::SwapSlot;
 #[cfg(feature = "atomic-arc")]
 mod atomic;
 
-pub use flavors::arc_swap::{bounded, raw_bounded, Publisher, Slot, Subscriber};
+pub use flavors::arc_swap::{bounded, raw_bounded, Publisher, Subscriber};

--- a/src/swap_slot.rs
+++ b/src/swap_slot.rs
@@ -14,34 +14,3 @@ pub trait SwapSlot<T> {
     /// but are required because of the bounded constraint.
     fn none() -> Self;
 }
-#[cfg(test)]
-mod test {
-    // uses the libraries default exported slot
-    use crate::swap_slot::SwapSlot;
-    use crate::Slot;
-    use std::sync::Arc;
-
-    #[test]
-    fn test_swap_slot() {
-        // Initialize slot
-        let item = Slot::none();
-
-        // Store an item into the slot, ref count = 1
-        SwapSlot::store(&item, 1);
-
-        // Load an item from the slot, ref count = 2
-        let arc = SwapSlot::load(&item);
-        assert_eq!(*arc, 1);
-        assert_eq!(Arc::strong_count(&arc), 2);
-
-        // Store another item into the slot overwriting the previous item.
-        // old item ref count drops to 1, new item ref count is 1.
-        SwapSlot::store(&item, 2);
-        assert_eq!(Arc::strong_count(&arc), 1);
-
-        // Load new item from the slot, ref count 2
-        let arc = SwapSlot::load(&item);
-        assert_eq!(*arc, 2);
-        assert_eq!(Arc::strong_count(&arc), 2);
-    }
-}

--- a/src/swap_slot.rs
+++ b/src/swap_slot.rs
@@ -5,9 +5,11 @@ pub trait SwapSlot<T> {
     /// Creates a new Arc around item and stores it,
     /// dropping the previously held item's Arc.
     fn store(&self, item: T);
+
     /// Returns a clone of the held Arc,
     /// incrementing the ref count atomically
-    fn load(&self) -> Arc<T>;
+    fn load(&self) -> Option<Arc<T>>;
+
     /// Creates a placeholder without an item.
     /// Due to the queue's internal implementation
     /// placeholders are never read, only overwritten,


### PR DESCRIPTION
- Remove tests for SwapSlot trait
- Remove default SwapSlot export Slot
- Update `SwapSlot` load method to return `Option<Arc<T>>`
- Update tests for flavors of `SwapSlot`

Closes #53
Closes #54